### PR TITLE
Fix: Switch 컴포넌트에 onChange 핸들러 추가로 read-only 오류 수정

### DIFF
--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -58,7 +58,7 @@ export interface SwitchProps
 const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   (
     {
-      checked = false,
+      checked,
       onCheckedChange,
       size = "md",
       disabled = false,
@@ -66,16 +66,21 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       className,
       label,
       labelPosition = "right",
+      defaultChecked = false,
       ...props
     },
     ref
   ) => {
-    // 내부 상태로 관리하여 애니메이션 처리를 개선
-    const [internalChecked, setInternalChecked] = useState(checked);
+    // 제어/비제어 상태 관리
+    const [internalChecked, setInternalChecked] = useState(
+      checked !== undefined ? checked : defaultChecked
+    );
 
-    // 외부에서 checked 값이 변경될 경우 내부 상태 업데이트
+    // 외부 checked prop이 변경될 때 내부 상태 동기화
     useEffect(() => {
-      setInternalChecked(checked);
+      if (checked !== undefined) {
+        setInternalChecked(checked);
+      }
     }, [checked]);
 
     // 스위치 사이즈에 따른 스타일
@@ -122,10 +127,23 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       error: "bg-[#EF4444]",
     };
 
+    // 클릭 핸들러 (커스텀 UI 클릭)
     const handleClick = () => {
       if (disabled) return;
 
       const newChecked = !internalChecked;
+      setInternalChecked(newChecked);
+
+      if (onCheckedChange) {
+        onCheckedChange(newChecked);
+      }
+    };
+
+    // 체크박스 변경 핸들러 (input 요소)
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (disabled) return;
+
+      const newChecked = event.target.checked;
       setInternalChecked(newChecked);
 
       if (onCheckedChange) {
@@ -158,6 +176,7 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>(
             type="checkbox"
             className="sr-only"
             checked={internalChecked}
+            onChange={handleChange}
             disabled={disabled}
             ref={ref}
             {...props}


### PR DESCRIPTION
# 🚀 개요
`Dropdown`과 `Switch` 컴포넌트에서 발생한 TypeScript 오류를 수정하고 동작을 개선했습니다. `Dropdown`의 `forwardRef` `ref` 파라미터 누락과 `Switch`의 `checked` prop read-only 문제를 해결했습니다.

## 🔍 변경사항
- `Dropdown`: `forwardRef`에 `ref` 파라미터 추가 및 내부 `useRef` 제거
- `Dropdown`: 외부 클릭 감지 로직을 `forwardRef` `ref`로 업데이트
- `Dropdown`: `DropdownProps`의 `disabled` 속성 오타 수정
- `Switch`: `<input type="checkbox">`에 `onChange` 핸들러 추가로 read-only 오류 해결
- `Switch`: 제어/비제어 모드 지원을 위해 `defaultChecked` 추가 및 상태 관리 개선
- `Switch`: `handleChange`와 `handleClick` 연계로 일관된 상태 업데이트

## ⏳ 작업 내용
- [x] `Dropdown.tsx`의 `forwardRef`에 `ref` 파라미터 추가 및 루트 `div`에 연결
- [x] `Dropdown`의 `useRef` 제거 및 외부 클릭 감지 로직 수정
- [x] `DropdownProps`의 `disabled` 오타 수정
- [x] `Switch.tsx`의 `<input>`에 `onChange` 핸들러 추가
- [x] `Switch`에 `defaultChecked` prop 추가 및 제어/비제어 로직 구현
- [x] `Switch`의 `handleChange`와 `handleClick` 통합
